### PR TITLE
Add list-builds example with pagination support

### DIFF
--- a/build-api/nodejs/README.md
+++ b/build-api/nodejs/README.md
@@ -14,3 +14,4 @@ Node.js files to interact with the API located in the `src/` directory:
 - create-project.js
 - delete-project.js
 - create-build.js
+- list-builds.js

--- a/build-api/nodejs/package-lock.json
+++ b/build-api/nodejs/package-lock.json
@@ -9,64 +9,49 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@depot/sdk-node": "^0.5.0"
+        "@depot/sdk-node": "^2.0.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.7.2.tgz",
-      "integrity": "sha512-i5GE2Dk5ekdlK1TR7SugY4LWRrKSfb5T1Qn4unpIMbfxoeGKERKQ59HG3iYewacGD10SR7UzevfPnh6my4tNmQ=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.9.0.tgz",
+      "integrity": "sha512-rnJenoStJ8nvmt9Gzye8nkYd6V22xUAnu4086ER7h1zJ508vStko4pMvDeQ446ilDTFpV5wnoc5YS7XvMwwMqA==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)",
+      "peer": true
     },
     "node_modules/@connectrpc/connect": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-0.13.2.tgz",
-      "integrity": "sha512-KZg6EH8gYnQZm/d2IXXMVB2mom/A1dCD8+7JScm2tKN9OQyQSeCJOLqtv/M4M5XVS0Y9JM2/VCbiUwfhl9Rqmg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-2.1.0.tgz",
+      "integrity": "sha512-xhiwnYlJNHzmFsRw+iSPIwXR/xweTvTw8x5HiwWp10sbVtd4OpOXbRgE7V58xs1EC17fzusF1f5uOAy24OkBuA==",
+      "license": "Apache-2.0",
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
+        "@bufbuild/protobuf": "^2.7.0"
       }
     },
     "node_modules/@connectrpc/connect-node": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-0.13.2.tgz",
-      "integrity": "sha512-dAoBuQ+fYFw22KYgZXPw1t19i6TRwNmk6c6XsOYLhBl1Y5vzXoMfMX2jm7lmkmLQFIcM9Xc2EYoUKtjNXH5bjw==",
-      "dependencies": {
-        "@connectrpc/connect": "0.13.2",
-        "undici": "^5.23.0"
-      },
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-2.1.0.tgz",
+      "integrity": "sha512-6akCXZSX5uWHLR654ne9Tnq7AnPUkLS65NvgsI5885xBkcuVy2APBd8sA4sLqaplUt84cVEr6LhjEFNx6W1KtQ==",
+      "license": "Apache-2.0",
       "engines": {
-        "node": ">=16.0.0"
+        "node": ">=20"
       },
       "peerDependencies": {
-        "@bufbuild/protobuf": "^1.2.1"
+        "@bufbuild/protobuf": "^2.7.0",
+        "@connectrpc/connect": "2.1.0"
       }
     },
     "node_modules/@depot/sdk-node": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@depot/sdk-node/-/sdk-node-0.5.0.tgz",
-      "integrity": "sha512-Pl9Yji00B6uQpMm5xZU4/eZbzaBo72N6c534ZqLI6nbOEIPH0VX27TVF9lFF3Fl3GHFZ+6X9laJtDn2DrLS2DQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@depot/sdk-node/-/sdk-node-2.0.0.tgz",
+      "integrity": "sha512-pZsPojzXKtsA8i2b9m9HLHRSUnhiEhKxfaGW43Ys3aXqLQbO8g9aGLiuijBGx4Vy3OpBKZvi1GOau1zlG8XHlg==",
+      "license": "MIT",
       "dependencies": {
-        "@bufbuild/protobuf": "^1.3.0",
-        "@connectrpc/connect": "^0.13.1",
-        "@connectrpc/connect-node": "^0.13.1"
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
-      "integrity": "sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/undici": {
-      "version": "5.28.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.3.tgz",
-      "integrity": "sha512-3ItfzbrhDlINjaP0duwnNsKpDQk3acHI3gVJ1z4fmwMK31k5G9OVIAMLSIaP6w4FaGkaAkN6zaQO9LUvZ1t7VA==",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
+        "@connectrpc/connect": "^2.1.0",
+        "@connectrpc/connect-node": "^2.1.0"
       },
-      "engines": {
-        "node": ">=14.0"
+      "peerDependencies": {
+        "@bufbuild/protobuf": ">=2, <3"
       }
     }
   }

--- a/build-api/nodejs/package.json
+++ b/build-api/nodejs/package.json
@@ -9,6 +9,6 @@
   "author": "kylegalbraith",
   "license": "ISC",
   "dependencies": {
-    "@depot/sdk-node": "^0.5.0"
+    "@depot/sdk-node": "^2.0.0"
   }
 }

--- a/build-api/nodejs/src/list-builds.js
+++ b/build-api/nodejs/src/list-builds.js
@@ -1,0 +1,147 @@
+const { depot } = require("@depot/sdk-node");
+
+const headers = {
+  Authorization: `Bearer ${process.env.DEPOT_TOKEN}`,
+};
+
+/**
+ * List builds for a project with pagination support
+ * Allows fetching more than 30 builds (up to any number you specify)
+ *
+ * @param {string} projectId - The project ID to list builds for
+ * @param {number} maxBuilds - Maximum number of builds to fetch (default: 100)
+ * @returns {Promise<Array>} - Array of builds
+ */
+async function listBuilds(projectId, maxBuilds = 100) {
+  let allBuilds = [];
+  let pageToken = undefined;
+  let hasMore = true;
+
+  // First, get the project to retrieve the organization ID
+  console.log(`Fetching project details...`);
+  const projectResult = await depot.core.v1.ProjectService.getProject(
+    { projectId: projectId },
+    { headers }
+  );
+  const organizationId = projectResult.project.organizationId;
+
+  console.log(`Fetching up to ${maxBuilds} builds for project ${projectId}...`);
+
+  while (hasMore && allBuilds.length < maxBuilds) {
+    // Calculate how many more builds we need
+    const pageSize = Math.min(100, maxBuilds - allBuilds.length);
+
+    const result = await depot.core.v1.BuildService.listBuilds(
+      {
+        projectId: projectId,
+        pageSize: pageSize,
+        pageToken: pageToken,
+      },
+      { headers }
+    );
+
+    if (result.builds && result.builds.length > 0) {
+      allBuilds = allBuilds.concat(result.builds);
+      console.log(
+        `Fetched ${result.builds.length} builds (total: ${allBuilds.length})`
+      );
+    }
+
+    // Check if there are more pages
+    if (result.nextPageToken) {
+      pageToken = result.nextPageToken;
+    } else {
+      hasMore = false;
+      console.log("No more builds available");
+    }
+  }
+
+  console.log(`\nTotal builds fetched: ${allBuilds.length}`);
+  return { builds: allBuilds, organizationId, projectId };
+}
+
+// Command line usage
+const args = process.argv.slice(2);
+const projectId = args[0];
+const maxBuilds = args[1] ? parseInt(args[1]) : 100;
+
+if (!projectId) {
+  console.error("Usage: node list-builds.js <project-id> [max-builds]");
+  console.error("\nExamples:");
+  console.error(
+    "  node list-builds.js abc123           # Fetch up to 100 builds"
+  );
+  console.error(
+    "  node list-builds.js abc123 50        # Fetch up to 50 builds"
+  );
+  console.error(
+    "  node list-builds.js abc123 200       # Fetch up to 200 builds"
+  );
+  console.error(
+    "  node list-builds.js abc123 500       # Fetch up to 500 builds"
+  );
+  process.exit(1);
+}
+
+// Map status enum to signal/emoji
+// https://buf.build/depot/api/docs/main:depot.core.v1#depot.core.v1.Build.Status
+function getStatusSignal(status) {
+  const statusMap = {
+    0: "❓", // STATUS_UNSPECIFIED
+    1: "⏳", // STATUS_RUNNING
+    2: "❌", // STATUS_FAILED
+    3: "✅", // STATUS_SUCCESS
+    4: "⚠️ ", // STATUS_ERROR
+    5: "🚫", // STATUS_CANCELLED
+  };
+  return statusMap[status] || "❓";
+}
+
+listBuilds(projectId, maxBuilds)
+  .then((result) => {
+    const { builds, organizationId, projectId } = result;
+    console.log("\n=== Build Details ===");
+    builds.forEach((build, index) => {
+      const buildUrl = `https://depot.dev/orgs/${organizationId}/projects/${projectId}/builds/${build.buildId}`;
+      console.log(
+        `\n${index + 1}. Build ID: ${build.buildId || "N/A"}`
+      );
+      console.log(`   URL: ${buildUrl}`);
+      if (build.createdAt) {
+        // Convert protobuf Timestamp to JavaScript Date
+        // Protobuf timestamps have seconds and nanos fields
+        const timestamp = build.createdAt.seconds
+          ? new Date(Number(build.createdAt.seconds) * 1000)
+          : build.createdAt.toDate
+          ? build.createdAt.toDate()
+          : new Date(build.createdAt);
+        console.log(`   Created: ${timestamp.toLocaleString()}`);
+      }
+      if (build.startedAt) {
+        const timestamp = build.startedAt.seconds
+          ? new Date(Number(build.startedAt.seconds) * 1000)
+          : build.startedAt.toDate
+          ? build.startedAt.toDate()
+          : new Date(build.startedAt);
+        console.log(`   Started: ${timestamp.toLocaleString()}`);
+      }
+      if (build.finishedAt) {
+        const timestamp = build.finishedAt.seconds
+          ? new Date(Number(build.finishedAt.seconds) * 1000)
+          : build.finishedAt.toDate
+          ? build.finishedAt.toDate()
+          : new Date(build.finishedAt);
+        console.log(`   Finished: ${timestamp.toLocaleString()}`);
+      }
+      if (build.status !== undefined) {
+        console.log(`   Status: ${getStatusSignal(build.status)}`);
+      }
+      if (build.buildDurationSeconds) {
+        console.log(`   Duration: ${build.buildDurationSeconds}s`);
+      }
+    });
+  })
+  .catch((error) => {
+    console.error("Error fetching builds:", error.message);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary

Adds a new `list-builds.js` example that demonstrates how to fetch more than 30 builds from the Depot API using pagination.

## Changes

- **New file**: `src/list-builds.js` - Example script to list builds with pagination
- **SDK upgrade**: Updated `@depot/sdk-node` from v0.5.0 to v2.0.0 to access `core.v1.BuildService.listBuilds`
- **Updated README**: Added list-builds.js to the examples list

## Features

- Fetches any number of builds (user-specified, default 100) using pagination
- Displays comprehensive build information:
  - Build ID with clickable dashboard URL
  - Timestamps (created, started, finished) properly converted from protobuf
  - Status with emoji indicators (✅ ❌ ⏳ ⚠️ 🚫)
  - Build duration
- Supports fetching 50, 100, 200, 500+ builds (beyond dashboard's 30 limit)

## Usage

```bash
node src/list-builds.js <project-id> [max-builds]
```

Examples:
```bash
node src/list-builds.js abc123           # Fetch up to 100 builds
node src/list-builds.js abc123 200       # Fetch up to 200 builds
```

## Test plan

- [x] Run script with valid project ID and various build limits
- [x] Verify timestamps display correctly
- [x] Verify status emojis match build states
- [x] Verify dashboard URLs are correctly formatted and clickable
- [x] Test pagination with projects having >100 builds