### PR TITLE
Add sandbox-vscode example for the Depot Sandbox SDK

### DIFF
--- a/sandbox-vscode/README.md
+++ b/sandbox-vscode/README.md
@@ -1,0 +1,54 @@
+# VS Code in a box, on a Depot sandbox
+
+Boot a fresh [Depot sandbox](https://depot.dev/docs/api/sandbox-sdk-reference), clone a set of
+GitHub repos into it, open them as a multi-root VS Code workspace, and reach the editor from any
+browser over a public HTTPS URL — in about 15 seconds, from a single TypeScript file.
+
+It starts from Depot's plain base image (no prebuilt image to maintain) and uses the
+[`@depot/sandbox`](https://www.npmjs.com/package/@depot/sandbox) SDK to do everything live:
+
+- **`Sandbox.create()`** boots a microVM from the base image.
+- **`sandbox.fs()`** writes config over a `node:fs/promises`-style filesystem — the repo list, and a
+  GitHub token for private repos.
+- **`sandbox.runCommand()`** clones the repos, installs [code-server](https://github.com/coder/code-server)
+  and [cloudflared](https://github.com/cloudflare/cloudflared), and streams the output back live.
+- **`{detached: true}`** keeps the editor, the Cloudflare tunnel, and the background `npm install`
+  running after the script exits.
+
+## Run it
+
+For private repos, set `GITHUB_TOKEN` — or just be logged in with the `gh` CLI (`gh auth login`) and
+the script will use that token automatically.
+
+```bash
+pnpm install
+
+DEPOT_TOKEN=...                       \
+REPOS="depot/cli sindresorhus/ky"     \
+  pnpm start
+```
+
+It prints a `https://<random>.trycloudflare.com` URL and a generated password. Open the URL, enter
+the password, and you're in your repos. `npm install` finishes in the background while you work.
+
+### Environment variables
+
+| Variable        | Required | Description                                                                    |
+| --------------- | -------- | ------------------------------------------------------------------------------ |
+| `DEPOT_TOKEN`   | yes      | Your Depot API token.                                                          |
+| `REPOS`         | yes      | `owner/repo` entries, separated by spaces, commas, or newlines.               |
+| `GITHUB_TOKEN`  | no       | GitHub token for private repos. Falls back to `gh auth token` if unset.        |
+| `DEPOT_ORG_ID`  | no       | Organization id, for app/service tokens or multi-org user tokens.             |
+
+## Tear it down
+
+Sandboxes stop themselves at their timeout (4 hours here), but you can kill one immediately:
+
+```ts
+import {createClient, Sandbox} from '@depot/sandbox'
+const client = createClient({token: process.env.DEPOT_TOKEN!})
+await Sandbox.get(client, 'your-sandbox-id').then((s) => s.kill())
+```
+
+> The Sandbox SDK is in private beta. [Contact us](https://depot.dev/help) to request access for
+> your organization.

--- a/sandbox-vscode/package.json
+++ b/sandbox-vscode/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "depot-sandbox-vscode-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Boot a remote, multi-repo VS Code dev environment on a Depot sandbox",
+  "scripts": {
+    "start": "tsx vscode-workspace.ts"
+  },
+  "dependencies": {
+    "@depot/sandbox": "^0.1.0-beta.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "tsx": "^4.19.2",
+    "typescript": "^6.0.3"
+  }
+}

--- a/sandbox-vscode/pnpm-lock.yaml
+++ b/sandbox-vscode/pnpm-lock.yaml
@@ -1,0 +1,369 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@depot/sandbox':
+        specifier: ^0.1.0-beta.3
+        version: 0.1.0-beta.3
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.3
+        version: 25.9.3
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@bufbuild/protobuf@2.11.0':
+    resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@connectrpc/connect-node@2.1.2':
+    resolution: {integrity: sha512-+i/aAOpsI8sIx1mbYp6d99zvxaUSF6t/jP9Ux9maAmjsZPgmIQ3JuIeYi0zJIP9zlCnBlJjkpPosshCgdRuThQ==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+      '@connectrpc/connect': 2.1.2
+
+  '@connectrpc/connect@2.1.2':
+    resolution: {integrity: sha512-MXkBijtcX09R10Eb6sFeIetc6w6746eio6xtfuyVOH7oQAacT1X0GzMIQFux6Qy8cq3W/T5qX5Bei8YbFtmRGA==}
+    peerDependencies:
+      '@bufbuild/protobuf': ^2.7.0
+
+  '@depot/sandbox@0.1.0-beta.3':
+    resolution: {integrity: sha512-XrRYSRMiFag/C4p0tT1hjwrC6ee8/U2iJJhlj7AvGG+H1gsUR25TPc9eZ+0jkrhSkW+nqRg0joA2QT6UriGftg==}
+    engines: {node: '>=20'}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/node@25.9.3':
+    resolution: {integrity: sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+snapshots:
+
+  '@bufbuild/protobuf@2.11.0': {}
+
+  '@connectrpc/connect-node@2.1.2(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.11.0))':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.11.0)
+
+  '@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.11.0)':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+
+  '@depot/sandbox@0.1.0-beta.3':
+    dependencies:
+      '@bufbuild/protobuf': 2.11.0
+      '@connectrpc/connect': 2.1.2(@bufbuild/protobuf@2.11.0)
+      '@connectrpc/connect-node': 2.1.2(@bufbuild/protobuf@2.11.0)(@connectrpc/connect@2.1.2(@bufbuild/protobuf@2.11.0))
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@types/node@25.9.3':
+    dependencies:
+      undici-types: 7.24.6
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@6.0.3: {}
+
+  undici-types@7.24.6: {}

--- a/sandbox-vscode/tsconfig.json
+++ b/sandbox-vscode/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["vscode-workspace.ts"]
+}

--- a/sandbox-vscode/vscode-workspace.ts
+++ b/sandbox-vscode/vscode-workspace.ts
@@ -146,20 +146,19 @@ try {
   ok('~/.bashrc wired')
 
   // code-server is the editor; cloudflared exposes it over a public HTTPS quick
-  // tunnel (no account, no DNS). Both are single static binaries: code-server's
-  // installer auto-detects arch, and we map uname -m -> cloudflared's asset arch.
+  // tunnel (no account, no DNS). Both are single static binaries — Depot's base
+  // image is x86_64, so we grab the amd64 cloudflared directly.
   step('Installing code-server + cloudflared')
   const install = await box.runCommand({
     cmd: '/bin/bash',
     args: [
       '-c',
       `set -e
-       case "$(uname -m)" in x86_64) cfarch=amd64;; aarch64|arm64) cfarch=arm64;; *) cfarch=amd64;; esac
        curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=${HOME}/.local
        mkdir -p ${HOME}/.local/bin
-       curl -fL --progress-bar "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$cfarch" -o ${HOME}/.local/bin/cloudflared
+       curl -fL --progress-bar "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-amd64" -o ${HOME}/.local/bin/cloudflared
        chmod +x ${HOME}/.local/bin/cloudflared
-       echo "  ${green('✓')} code-server + cloudflared (linux-$cfarch) installed"`,
+       echo "  ${green('✓')} code-server + cloudflared installed"`,
     ],
   })
   for await (const chunk of install.logs()) process.stdout.write(chunk.data)
@@ -185,18 +184,18 @@ try {
     detached: true,
   })
 
-  // Warm the workspace in the background: run `npm install` in every repo at
-  // once, detached, so dependencies are landing while you're already in the
-  // editor. node + npm ship in the base image, so there's nothing to set up.
-  step('Kicking off background warm-up (npm install in every repo)')
+  // Warm the workspace in the background: in every repo at once, detached,
+  // backfill full git history (we cloned shallow) and run `npm install` — so
+  // it's all landing while you're already in the editor. node + npm + git ship
+  // in the base image, so there's nothing to set up.
+  step('Kicking off background warm-up (unshallow + npm install in every repo)')
   await box.runCommand({
     cmd: '/bin/bash',
     args: [
       '-c',
       `cd ${HOME}/ws
-       for d in */; do ( cd "$d" && [ -f package.json ] && npm install && echo "npm install: $d ✓" ) & done
-       wait
-       echo done`,
+       for d in */; do ( cd "$d" && git fetch --unshallow >/dev/null 2>&1; [ -f package.json ] && npm install ) & done
+       wait`,
     ],
     detached: true,
   })

--- a/sandbox-vscode/vscode-workspace.ts
+++ b/sandbox-vscode/vscode-workspace.ts
@@ -1,0 +1,241 @@
+// VS Code in a box — a remote, multi-repo dev environment provisioned live on a
+// Depot sandbox through the @depot/sandbox SDK, reachable from any browser via a
+// Cloudflare quick tunnel. No prebuilt image: we boot Depot's plain base image
+// and turn it into an authenticated, multi-repo VS Code in seconds.
+//
+//   DEPOT_TOKEN=...  \
+//   REPOS="depot/cli sindresorhus/ky"  \
+//     pnpm tsx vscode-workspace.ts
+//
+// For private repos it authenticates GitHub with a token — either GITHUB_TOKEN,
+// or, if that's unset, whatever your local `gh` CLI is logged in as. With
+// neither it clones public repos only.
+//
+// The SDK surface on display (all documented at
+// https://depot.dev/docs/api/sandbox-sdk-reference):
+//   Sandbox.create()      — boot a VM from the base image
+//   sandbox.fs()          — a node:fs/promises-style filesystem, over RPC
+//   sandbox.runCommand()  — run a command; stream .logs(), await .wait()/.output()
+//   { detached: true }    — long-lived background processes (the editor, the tunnel)
+
+import {execFile} from 'node:child_process'
+import {randomBytes} from 'node:crypto'
+import {promisify} from 'node:util'
+import {createClient, Sandbox, type DirEntry} from '@depot/sandbox'
+
+const execFileAsync = promisify(execFile)
+
+// ── config, all from the environment — nothing about your laptop ───────────
+const need = (name: string): string => {
+  const v = process.env[name]
+  if (!v) throw new Error(`Missing required env var ${name}`)
+  return v
+}
+
+// `owner/repo` entries, separated by spaces, commas, or newlines.
+const REPOS = need('REPOS')
+  .split(/[\s,]+/)
+  .filter(Boolean)
+const client = createClient({token: need('DEPOT_TOKEN'), orgID: process.env.DEPOT_ORG_ID})
+
+// A GitHub token for cloning private repos: GITHUB_TOKEN if set, otherwise ask
+// the local gh CLI (`gh auth token` works whether gh stores the token in a file
+// or the OS keyring). Undefined → clone public repos only.
+const githubToken = async (): Promise<string | undefined> => {
+  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN
+  try {
+    const {stdout} = await execFileAsync('gh', ['auth', 'token'])
+    return stdout.trim() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+const HOME = '/home/runner'
+const PORT = 8080
+const PASSWORD = randomBytes(12).toString('base64url')
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// ── tiny ANSI palette (demo polish, no deps) ──────────────────────────────
+const paint = (code: string) => (s: string | number) => `\x1b[${code}m${s}\x1b[0m`
+const bold = paint('1')
+const dim = paint('2')
+const green = paint('32')
+const yellow = paint('33')
+const cyan = paint('36')
+const step = (s: string) => console.log(`\n${cyan('▸')} ${bold(s)}`)
+const ok = (s: string) => console.log(`  ${green('✓')} ${s}`)
+
+const t0 = Date.now()
+console.log(bold(`\n  Provisioning a ${REPOS.length}-repo VS Code workspace on a fresh Depot sandbox.`))
+
+// Boot from the base image. No runtime → Depot's pre-cached default base image
+// (Ubuntu 24.04), which runs natively on Depot's microVMs and boots in seconds.
+step('Booting a sandbox from the base image')
+const box = await Sandbox.create(client, {
+  name: 'depot-workspace-box',
+  resources: {vcpus: 8, memoryMb: 16384},
+  timeoutMinutes: 240,
+})
+ok(`${box.sandboxId} — ${green(box.status ?? '?')} in ${yellow(`${Date.now() - t0}ms`)}`)
+
+try {
+  // The filesystem API mirrors node:fs/promises. Write the repo list, and (for
+  // private repos) drop a token where gh expects it, so it never appears on a
+  // command line. node:fs/promises shapes mean readFile/writeFile/mkdir, etc.
+  step('Writing config with the fs module')
+  const fs = box.fs()
+  await fs.writeFile(`${HOME}/repos.txt`, REPOS.join('\n'))
+
+  const token = await githubToken()
+  if (token) {
+    await fs.mkdir(`${HOME}/.config/gh`, {recursive: true})
+    await fs.writeFile(`${HOME}/.config/gh/hosts.yml`, `github.com:\n    oauth_token: ${token}\n    git_protocol: https\n`)
+    await fs.chmod(`${HOME}/.config/gh/hosts.yml`, 0o600)
+    ok('repos.txt + hosts.yml written over RPC')
+  } else {
+    ok('repos.txt written over RPC (no token — cloning public repos)')
+  }
+
+  // gh and git already ship in the base image — just wire them up. runCommand
+  // is a server-streaming call: iterate .logs() to watch output live, then
+  // await .wait() for the command to finish.
+  if (token) {
+    step('Authenticating git')
+    const auth = await box.runCommand({
+      cmd: '/bin/bash',
+      args: [
+        '-c',
+        'gh auth setup-git && git config --global user.name "$(gh api user --jq .name)" && echo "authed as $(gh api user --jq .login)"',
+      ],
+    })
+    for await (const chunk of auth.logs()) process.stdout.write(dim(chunk.data))
+    await auth.wait()
+  }
+
+  // Clone everything, shallow + parallel — watch it land repo by repo.
+  step(`Cloning ${REPOS.length} repos (shallow, 8-way parallel)`)
+  const clone = await box.runCommand({
+    cmd: '/bin/bash',
+    args: [
+      '-c',
+      `mkdir -p ${HOME}/ws && cd ${HOME}/ws
+       xargs -P8 -I{} bash -c 'git clone --depth 1 https://github.com/{}.git >/dev/null 2>&1 && echo "  ${green('✓')} {}" || echo "  ${yellow('✗')} {}"' < ${HOME}/repos.txt`,
+    ],
+  })
+  for await (const chunk of clone.logs()) process.stdout.write(chunk.data)
+  await clone.wait()
+
+  // Build the multi-root workspace file — fs again, this time readdir + write.
+  step('Generating the .code-workspace')
+  const entries = (await fs.readdir(`${HOME}/ws`, {withFileTypes: true})) as DirEntry[]
+  const folders = entries
+    .filter((e) => e.isDirectory())
+    .map((e) => ({path: e.name, name: e.name}))
+    .sort((a, b) => a.name.localeCompare(b.name))
+  await fs.writeFile(
+    `${HOME}/ws/workspace.code-workspace`,
+    JSON.stringify({folders, settings: {'git.openRepositoryInParentFolders': 'always'}}, null, 2),
+  )
+  ok(`${folders.length} folders`)
+
+  // ~/.local/bin isn't on the base PATH, so put it there for the editor's
+  // terminal (fs.appendFile, no clobber) — that's where code-server lands.
+  step('Wiring the terminal shell (PATH)')
+  await fs.appendFile(`${HOME}/.bashrc`, '\n# depot workspace box\nexport PATH="$HOME/.local/bin:$PATH"\n')
+  ok('~/.bashrc wired')
+
+  // code-server is the editor; cloudflared exposes it over a public HTTPS quick
+  // tunnel (no account, no DNS). Both are single static binaries: code-server's
+  // installer auto-detects arch, and we map uname -m -> cloudflared's asset arch.
+  step('Installing code-server + cloudflared')
+  const install = await box.runCommand({
+    cmd: '/bin/bash',
+    args: [
+      '-c',
+      `set -e
+       case "$(uname -m)" in x86_64) cfarch=amd64;; aarch64|arm64) cfarch=arm64;; *) cfarch=amd64;; esac
+       curl -fsSL https://code-server.dev/install.sh | sh -s -- --method=standalone --prefix=${HOME}/.local
+       mkdir -p ${HOME}/.local/bin
+       curl -fL --progress-bar "https://github.com/cloudflare/cloudflared/releases/latest/download/cloudflared-linux-$cfarch" -o ${HOME}/.local/bin/cloudflared
+       chmod +x ${HOME}/.local/bin/cloudflared
+       echo "  ${green('✓')} code-server + cloudflared (linux-$cfarch) installed"`,
+    ],
+  })
+  for await (const chunk of install.logs()) process.stdout.write(chunk.data)
+  await install.wait()
+
+  // Long-lived processes run detached, so they outlive this script. detached is
+  // still beta, so the SDK prints a notice per launch — we let it show.
+  // code-server reads its password from $PASSWORD; binding to localhost is fine
+  // because Cloudflare terminates TLS and proxies in.
+  step('Serving the editor behind a Cloudflare quick tunnel (detached)')
+  await box.runCommand({
+    cmd: '/bin/bash',
+    args: [
+      '-c',
+      `${HOME}/.local/bin/code-server --bind-addr 127.0.0.1:${PORT} --auth password ${HOME}/ws/workspace.code-workspace >/tmp/cs.log 2>&1`,
+    ],
+    env: {PASSWORD},
+    detached: true,
+  })
+  await box.runCommand({
+    cmd: '/bin/bash',
+    args: ['-c', `${HOME}/.local/bin/cloudflared tunnel --no-autoupdate --url http://localhost:${PORT} >/tmp/cf.log 2>&1`],
+    detached: true,
+  })
+
+  // Warm the workspace in the background: run `npm install` in every repo at
+  // once, detached, so dependencies are landing while you're already in the
+  // editor. node + npm ship in the base image, so there's nothing to set up.
+  step('Kicking off background warm-up (npm install in every repo)')
+  await box.runCommand({
+    cmd: '/bin/bash',
+    args: [
+      '-c',
+      `cd ${HOME}/ws
+       for d in */; do ( cd "$d" && [ -f package.json ] && npm install && echo "npm install: $d ✓" ) & done
+       wait
+       echo done`,
+    ],
+    detached: true,
+  })
+  ok('running in background')
+
+  // When I just want the output, .output() waits for the command and returns
+  // everything it printed. Poll cf.log for the public URL the tunnel printed.
+  step('Waiting for the public URL')
+  let url = ''
+  for (let i = 0; i < 45 && !url; i++) {
+    const grep = await box.runCommand({
+      cmd: '/bin/bash',
+      args: ['-c', `grep -Eo 'https://[a-z0-9-]+\\.trycloudflare\\.com' /tmp/cf.log | head -1`],
+    })
+    url = (await grep.output()).trim()
+    if (!url) await sleep(1000)
+  }
+  const probe = await box.runCommand({
+    cmd: '/bin/bash',
+    args: ['-c', `curl -s -o /dev/null -w '%{http_code}' http://localhost:${PORT}/login || echo 000`],
+  })
+  const health = (await probe.output()).trim()
+
+  const line = cyan('─'.repeat(64))
+  console.log(`\n${line}`)
+  console.log(`  ${bold('Your workspace is live')} — ${green(`${folders.length} repos`)}, git authed, zero clicks`)
+  console.log(
+    `  ${dim('booted + provisioned in')} ${yellow(`${((Date.now() - t0) / 1000).toFixed(1)}s`)}` +
+      `  ${dim('· editor health')} ${health.startsWith('2') ? green(health) : yellow(health)}`,
+  )
+  console.log(`\n  ${bold('OPEN')}     ${cyan(url || '(no URL yet — check /tmp/cf.log)')}`)
+  console.log(`  ${bold('PASSWORD')} ${PASSWORD}\n`)
+  console.log(dim(`  npm installs are finishing in the background across all repos`))
+  console.log(dim(`  tear down: Sandbox.get(client, '${box.sandboxId}').then((s) => s.kill())`))
+  console.log(line)
+} catch (err) {
+  console.error(`\n✗ ${err instanceof Error ? err.message : err}`)
+  await box.kill().catch(() => {})
+  process.exit(1)
+}
+
+process.exit(0) // detached streams leave an HTTP/2 handle open; exit cleanly.


### PR DESCRIPTION
A single TypeScript file that boots a Depot sandbox with [`@depot/sandbox`](https://www.npmjs.com/package/@depot/sandbox), clones a set of GitHub repos into it, opens them as a multi-root VS Code workspace, and exposes the editor over a Cloudflare quick tunnel — reachable from any browser in about fifteen seconds, starting from the plain base image.

It demonstrates the SDK end to end:

- `Sandbox.create()` boots a microVM from the base image.
- `sandbox.fs()` writes config over a `node:fs/promises`-style filesystem (the repo list, and a GitHub token for private repos).
- `sandbox.runCommand()` clones the repos and installs the editor, streaming output back live.
- `{detached: true}` keeps the editor, the tunnel, and a background `npm install` running after the script exits.

GitHub auth uses `GITHUB_TOKEN` if set, otherwise falls back to the local `gh` CLI's token. Verified end to end against production.

This is the runnable companion to the Sandbox SDK announcement post.

🤖 Generated with [Claude Code](https://claude.com/claude-code)